### PR TITLE
fixed a couple bugs with excludes

### DIFF
--- a/lib/types.js
+++ b/lib/types.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const Gql = require('graphql-tag');
-const cloneDeep = require('lodash.clonedeep');
+const CloneDeep = require('lodash.clonedeep');
 
 const debug = require('debug')('graphql-component:types');
 
@@ -19,7 +19,7 @@ const exclude = function (types, excludes) {
     return types;
   }
 
-  const typesCopy = cloneDeep(types);
+  const typesCopy = CloneDeep(types);
 
   for (const doc of typesCopy) {
     for (const def of doc.definitions) {

--- a/lib/types.js
+++ b/lib/types.js
@@ -1,7 +1,6 @@
 'use strict';
 
-const Gql = require('graphql-tag');
-const CloneDeep = require('lodash.clonedeep');
+const {parse} = require('graphql');
 
 const debug = require('debug')('graphql-component:types');
 
@@ -19,9 +18,7 @@ const exclude = function (types, excludes) {
     return types;
   }
 
-  const typesCopy = CloneDeep(types);
-
-  for (const doc of typesCopy) {
+  for (const doc of types) {
     for (const def of doc.definitions) {
       if (def.kind !== 'ObjectTypeDefinition') {
         continue;
@@ -38,68 +35,13 @@ const exclude = function (types, excludes) {
     }
   }
 
-  return typesCopy;
-}
-
-const excludeImmutable = function (types, excludes) {
-  if (!excludes || excludes.length < 1) {
-    return types;
-  }
-
-  let mutations = [];
-
-  for (let typeIndex = 0; typeIndex < types.length; typeIndex++) {
-    const doc = types[typeIndex];
-    for (let defIndex = 0; defIndex < doc.definitions.length; defIndex++) {
-      const def = doc.definitions[defIndex];
-      if (def.kind !== 'ObjectTypeDefinition') {
-        continue;
-      }
-      if (['Query', 'Mutation', 'Subscription'].indexOf(def.name.value) > -1) {
-        let fields = def.fields.filter((field) => {
-          if (check(def.name.value, field.name.value, excludes)) {
-            debug(`excluding ${def.name.value}.${field.name.value} from import`);
-            return false;
-          }
-          return true;
-        });
-
-        if (fields.length !== def.fields.length) {
-          mutations.push({
-            typeIndex,
-            defIndex,
-            fields
-          });
-        }
-      }
-    }
-  }
-
-  for (const mutation of mutations) {
-    const doc = types[mutation.typeIndex];
-    const definition = doc.definitions[mutation.defIndex];
-
-    const newDefinitions = [
-      ...doc.definitions
-    ];
-    newDefinitions[mutation.defIndex] = {
-      ...definition,
-      fields: mutation.fields
-    };
-
-    types[mutation.typeIndex] = {
-      ...doc,
-      definitions: newDefinitions
-    };
-  }
-
   return types;
 }
 
 const getImportedTypes = function (component, excludes) {
-  const types = component._types.map((type) => Gql`${type}`);
+  const types = component._types.map((type) => parse(type));
   const importedTypes = component._importedTypes;
-  return excludeImmutable([...types, ...importedTypes], excludes);
+  return exclude([...types, ...importedTypes], excludes);
 };
 
 module.exports = { exclude, check, getImportedTypes };

--- a/lib/types.js
+++ b/lib/types.js
@@ -41,10 +41,65 @@ const exclude = function (types, excludes) {
   return typesCopy;
 }
 
+const excludeImmutable = function (types, excludes) {
+  if (!excludes || excludes.length < 1) {
+    return types;
+  }
+
+  let mutations = [];
+
+  for (let typeIndex = 0; typeIndex < types.length; typeIndex++) {
+    const doc = types[typeIndex];
+    for (let defIndex = 0; defIndex < doc.definitions.length; defIndex++) {
+      const def = doc.definitions[defIndex];
+      if (def.kind !== 'ObjectTypeDefinition') {
+        continue;
+      }
+      if (['Query', 'Mutation', 'Subscription'].indexOf(def.name.value) > -1) {
+        let fields = def.fields.filter((field) => {
+          if (check(def.name.value, field.name.value, excludes)) {
+            debug(`excluding ${def.name.value}.${field.name.value} from import`);
+            return false;
+          }
+          return true;
+        });
+
+        if (fields.length !== def.fields.length) {
+          mutations.push({
+            typeIndex,
+            defIndex,
+            fields
+          });
+        }
+      }
+    }
+  }
+
+  for (const mutation of mutations) {
+    const doc = types[mutation.typeIndex];
+    const definition = doc.definitions[mutation.defIndex];
+
+    const newDefinitions = [
+      ...doc.definitions
+    ];
+    newDefinitions[mutation.defIndex] = {
+      ...definition,
+      fields: mutation.fields
+    };
+
+    types[mutation.typeIndex] = {
+      ...doc,
+      definitions: newDefinitions
+    };
+  }
+
+  return types;
+}
+
 const getImportedTypes = function (component, excludes) {
   const types = component._types.map((type) => Gql`${type}`);
   const importedTypes = component._importedTypes;
-  return exclude([...types, ...importedTypes], excludes);
+  return excludeImmutable([...types, ...importedTypes], excludes);
 };
 
 module.exports = { exclude, check, getImportedTypes };

--- a/lib/types.js
+++ b/lib/types.js
@@ -1,11 +1,12 @@
 'use strict';
 
 const Gql = require('graphql-tag');
+const cloneDeep = require('lodash.clonedeep');
 
 const debug = require('debug')('graphql-component:types');
 
 const check = function (operation, fieldName, excludes) {
-  for (const [root, name] in excludes) {
+  for (const [root, name] of excludes) {
     if (root === '*') {
       return true;
     }
@@ -18,14 +19,16 @@ const exclude = function (types, excludes) {
     return types;
   }
 
-  for (const doc of types) {
+  const typesCopy = cloneDeep(types);
+
+  for (const doc of typesCopy) {
     for (const def of doc.definitions) {
       if (def.kind !== 'ObjectTypeDefinition') {
         continue;
       }
       if (['Query', 'Mutation', 'Subscription'].indexOf(def.name.value) > -1) {
         def.fields = def.fields.filter((field) => {
-          if (!check(def.name.value, field.name.value, excludes)) {
+          if (check(def.name.value, field.name.value, excludes)) {
             debug(`excluding ${def.name.value}.${field.name.value} from import`);
             return false;
           }
@@ -35,7 +38,7 @@ const exclude = function (types, excludes) {
     }
   }
 
-  return types;
+  return typesCopy;
 }
 
 const getImportedTypes = function (component, excludes) {

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "graphql-extensions": "^0.5.2",
     "graphql-tag": "^2.10.1",
     "graphql-toolkit": "^0.2.0",
-    "graphql-tools": "^4.0.3"
+    "graphql-tools": "^4.0.3",
+    "lodash.clonedeep": "^4.5.0"
   },
   "peerDependencies": {
     "graphql": "^0.13.2"

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "graphql-extensions": "^0.5.2",
     "graphql-tag": "^2.10.1",
     "graphql-toolkit": "^0.2.0",
-    "graphql-tools": "^4.0.3",
+    "graphql-tools": "^4.0.3"
   },
   "peerDependencies": {
     "graphql": "^0.13.2"

--- a/package.json
+++ b/package.json
@@ -19,7 +19,6 @@
     "graphql-tag": "^2.10.1",
     "graphql-toolkit": "^0.2.0",
     "graphql-tools": "^4.0.3",
-    "lodash.clonedeep": "^4.5.0"
   },
   "peerDependencies": {
     "graphql": "^0.13.2"

--- a/test/test-types.js
+++ b/test/test-types.js
@@ -1,0 +1,152 @@
+'use strict';
+
+const Test = require('tape');
+var { buildASTSchema } = require('graphql');
+const Gql = require('graphql-tag')
+const Types = require('../lib/types');
+
+Test('type utilities', (t) => {
+
+  t.test('get types', (t) => {
+
+    t.plan(2);
+
+    const component = {
+      _importedTypes: [],
+      _types: [`
+        type A {
+          value: String
+        }
+        type Query {
+          a: A
+        }
+      `]
+    };
+
+    const types = Types.getImportedTypes(component);
+    const schema = buildASTSchema(types[0]);
+
+
+    t.ok(schema.getType('A').getFields().value, 'the "A" type exists');
+    t.ok(schema.getQueryType().getFields().a, 'the "a" query exists');
+  });
+
+  t.test('get imported types', (t) => {
+
+    t.plan(4);
+
+    const component = {
+      _importedTypes: [Gql`
+        type B {
+          value: String
+        }
+        type Query {
+          b: B
+        }
+      `],
+      _types: [`
+        type A {
+          value: String
+        }
+        type Query {
+          a: A
+        }
+      `]
+    };
+
+    const types = Types.getImportedTypes(component);
+    const schemaA = buildASTSchema(types[0]);
+    t.ok(schemaA.getType('A').getFields().value, 'the "A" type exists');
+    t.ok(schemaA.getQueryType().getFields().a, 'the "a" query exists');
+
+    const schemaB = buildASTSchema(types[1])
+    t.ok(schemaB.getType('B').getFields().value, 'the "B" type exists');
+    t.ok(schemaB.getQueryType().getFields().b, 'the "b" query exists');
+  });
+
+  t.test('exclude', (t) => {
+
+    t.plan(4);
+
+    const component = {
+      _importedTypes: [Gql`
+        type B {
+          value: String
+        }
+        type Query {
+          b: B
+        }
+      `],
+      _types: [`
+        type A {
+          value: String
+        }
+        type Query {
+          a: A
+        }
+      `]
+    };
+
+    const types = Types.getImportedTypes(component, [['Query', 'b']]);
+    const schemaA = buildASTSchema(types[0]);
+    t.ok(schemaA.getType('A').getFields().value, 'the "A" type exists');
+    t.ok(schemaA.getQueryType().getFields().a, 'the "a" query exists');
+
+    const schemaB = buildASTSchema(types[1])
+    t.ok(schemaB.getType('B').getFields().value, 'the "B" type exists');
+    t.notOk(schemaB.getQueryType().getFields().b, 'the "b" query does not exist');
+  });
+
+  t.test('exclude caching', (t) => {
+
+    t.plan(4);
+
+    const component = {
+      _importedTypes: [],
+      _types: [`
+        type A {
+          value: String
+        }
+        type Query {
+          a: A
+        }
+      `]
+    };
+
+    let types = Types.getImportedTypes(component, [['Query', 'a']]);
+    let schema = buildASTSchema(types[0]);
+    t.ok(schema.getType('A').getFields().value, 'the "A" type exists');
+    t.notOk(schema.getQueryType().getFields().a, 'the "a" query does not exist');
+
+    types = Types.getImportedTypes(component);
+    schema = buildASTSchema(types[0]);
+    t.ok(schema.getType('A').getFields().value, 'the "A" type exists');
+    t.ok(schema.getQueryType().getFields().a, 'the "a" query exists');
+  });
+
+  t.test('exclude all', (t) => {
+
+    t.plan(2);
+
+    const component = {
+      _importedTypes: [],
+      _types: [`
+        type A {
+          value: String
+        }
+        type Query {
+          a: A
+        }
+        type Mutation {
+          a: A
+        }
+      `]
+    };
+
+    const types = Types.getImportedTypes(component, [['*']]);
+    const schema = buildASTSchema(types[0]);
+    t.notOk(schema.getQueryType().getFields().a, 'the "a" query does not exist');
+    t.notOk(schema.getMutationType().getFields().a, 'the "a" mutation does not exist');
+  });
+
+});

--- a/test/test-types.js
+++ b/test/test-types.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const Test = require('tape');
-var { buildASTSchema } = require('graphql');
+const { buildASTSchema } = require('graphql');
 const Gql = require('graphql-tag')
 const Types = require('../lib/types');
 


### PR DESCRIPTION
`graphql-tag` keeps a cache of its parsing results, which is mutated [here](https://github.com/tlivings/graphql-component/blob/34a93953f93498e44bac7109ee33bb387857896f/lib/types.js#L27) when processing excludes. I've added a test that reproduces the issue as well as added additional tests to increase the coverage of types.js. While testing, I discovered and fixed another issue with how the excludes config is handled.