### PR TITLE
fix transitive mocks

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -70,7 +70,7 @@ class GraphQLComponent {
     this._importedResolvers = mergeResolvers(importedResolvers);
 
     this._useMocks = useMocks;
-    this._importedMocks = Object.assign({}, ...this._imports.map((c) => c.mocks));
+    this._importedMocks = Object.assign({}, ...this._imports.map((c) => Object.assign({}, c.mocks, c._importedMocks)));
     this._mocks = mocks && mocks(this._importedMocks);
     this._preserveTypeResolvers = preserveTypeResolvers;
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -70,7 +70,7 @@ class GraphQLComponent {
     this._importedResolvers = mergeResolvers(importedResolvers);
 
     this._useMocks = useMocks;
-    this._importedMocks = Object.assign({}, ...this._imports.map((c) => Object.assign({}, c.mocks, c._importedMocks)));
+    this._importedMocks = Object.assign({}, ...this._imports.map((c) => ({ ...c.mocks, ...c._importedMocks})));
     this._mocks = mocks && mocks(this._importedMocks);
     this._preserveTypeResolvers = preserveTypeResolvers;
 

--- a/test/test-mocks.js
+++ b/test/test-mocks.js
@@ -1,0 +1,75 @@
+'use strict';
+
+const Test = require('tape');
+const GraphQLComponent = require('../lib/index');
+
+Test('test component mocks', (t) => {
+  t.test('imported mocks', async (t) => {
+    t.plan(6);
+
+    const componentA = new GraphQLComponent({
+      types: [`
+        type A {
+          value: String
+        }
+        type Query {
+          a: A
+        }
+      `],
+      mocks: () => ({
+        A: () => ({value: 'a'})
+      })
+    });
+
+    const componentB = new GraphQLComponent({
+      types: [`
+        type B {
+          value: String
+        }
+        type Query {
+          b: B
+        }
+      `],
+      imports: [
+        componentA
+      ],
+      mocks: () => ({
+        B: () => ({value: 'b'})
+      })
+    });
+
+    const componentC = new GraphQLComponent({
+      types: [`
+        type C {
+          value: String
+        }
+        type Query {
+          c: C
+        }
+      `],
+      imports: [
+        componentB
+      ],
+      mocks: () => ({
+        C: () => ({value: 'c'})
+      }),
+      useMocks: true
+    });
+
+    t.equal(componentB._importedMocks.A, componentA.mocks.A, 'component B has component A\'s mocks');
+    t.equal(componentC._importedMocks.B, componentB.mocks.B, 'component C has component B\'s mocks');
+    t.equal(componentC._importedMocks.A, componentA.mocks.A, 'component C has component A\'s mocks');
+
+    const query = `
+      query {
+        a { value }
+        b { value }
+        c { value }
+      }
+    `;
+    const result = await componentC.execute(query);
+    t.equal(result.data.a.value, 'a', 'returns Component A\'s mock');
+    t.equal(result.data.b.value, 'b', 'returns Component B\'s mock');
+    t.equal(result.data.c.value, 'c', 'returns Component C\'s mock');
+  });
+});


### PR DESCRIPTION
Given 3 components: `A`, `B`, and `C` where `C` imports `B` and `B` imports `A`.
`A`'s mocks were missing from `C` because the `_importedMocks` field was built from `imported.mocks` rather than `imported._importedMocks + imported.mocks`.

