### PR TITLE
updated dependencies to resolve npm audit warnings

### DIFF
--- a/lib/resolvers.js
+++ b/lib/resolvers.js
@@ -2,11 +2,12 @@
 
 const debug = require('debug')('graphql-component:resolver');
 const { mergeResolvers } = require('graphql-toolkit');
+const { GraphQLScalarType } = require('graphql');
 
 const memoize = function (parentType, fieldName, resolve) {
   const _cache = new WeakMap();
 
-  return function (_, args, context, info ) {
+  return function (_, args, context, info) {
     const key = JSON.stringify(args);
 
     debug(`executing ${parentType}.${fieldName}`);
@@ -56,19 +57,22 @@ const wrapResolvers = function (bind, resolvers = {}) {
   const wrapped = {};
 
   for (const [name, value] of Object.entries(resolvers)) {
-    if (!wrapped[name]) {
-      wrapped[name] = {};
-    }
-
-    for (const [resolverName, func] of Object.entries(value)) {
-      if (wrapped[name][resolverName]) {
-        continue;
+    if (value instanceof GraphQLScalarType) {
+      wrapped[name] = value;
+    } else {
+      if (!wrapped[name]) {
+        wrapped[name] = {};
       }
-      debug(`memoized ${name}.${resolverName}`);
-      wrapped[name][resolverName] = memoize(name, resolverName, func.bind(bind));
+
+      for (const [resolverName, func] of Object.entries(value)) {
+        if (wrapped[name][resolverName]) {
+          continue;
+        }
+        debug(`memoized ${name}.${resolverName}`);
+        wrapped[name][resolverName] = memoize(name, resolverName, func.bind(bind));
+      }
     }
   }
-
   return wrapped;
 };
 

--- a/package.json
+++ b/package.json
@@ -17,8 +17,8 @@
     "debug": "^4.1.0",
     "graphql-extensions": "^0.5.2",
     "graphql-tag": "^2.10.1",
-    "graphql-toolkit": "^0.2.0",
-    "graphql-tools": "^4.0.3"
+    "graphql-toolkit": "^0.4.1",
+    "graphql-tools": "^4.0.5"
   },
   "peerDependencies": {
     "graphql": "^0.13.2"
@@ -26,9 +26,9 @@
   "devDependencies": {
     "apollo-server": "^2.0.7",
     "casual": "^1.6.0",
-    "eslint": "^5.14.1",
+    "eslint": "^6.1.0",
     "graphql": "^0.13.2",
-    "nyc": "^13.3.0",
+    "nyc": "^14.1.1",
     "tape": "^4.9.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -17,17 +17,18 @@
     "debug": "^4.1.0",
     "graphql-extensions": "^0.5.2",
     "graphql-tag": "^2.10.1",
+    "graphql-tag-pluck": "^0.8.3",
     "graphql-toolkit": "^0.4.1",
     "graphql-tools": "^4.0.5"
   },
   "peerDependencies": {
-    "graphql": "^0.13.2"
+    "graphql": "^14.4.2"
   },
   "devDependencies": {
     "apollo-server": "^2.0.7",
     "casual": "^1.6.0",
     "eslint": "^6.1.0",
-    "graphql": "^0.13.2",
+    "graphql": "^14.4.2",
     "nyc": "^14.1.1",
     "tape": "^4.9.1"
   }


### PR DESCRIPTION
Couple bumps to resolve a lodash security warning (high) also added fix for #21 allowing scalars in resolvers.