### PR TITLE
fix binding of 'this' to datasource instance methods

### DIFF
--- a/lib/datasource.js
+++ b/lib/datasource.js
@@ -13,7 +13,7 @@ const intercept = function (instance, context) {
       const original = target[key];
       
       return function (...args) {
-        return original(context, ...args);
+        return original.call(instance, context, ...args);
       };
     }
   });

--- a/test/test-datasource.js
+++ b/test/test-datasource.js
@@ -7,9 +7,12 @@ const GraphQLComponent = require('../lib/index');
 Test('dataSource', (t) => {
 
   t.test('intercept proxy', (t) => {
-    t.plan(3);
+    t.plan(4);
 
     const proxy = intercept(new class DataSource {
+      constructor() {
+        this.instanceField = 'some instance field value'
+      }
       static get name() {
         return 'TestDataSource';
       }
@@ -17,6 +20,7 @@ Test('dataSource', (t) => {
         t.equal(args.length, 2, 'added additional arg');
         t.equal(args[0].data, 'test', 'injected the right data');
         t.equal(args[1], 'test', 'data still passed to original call');
+        t.equal(this.instanceField, 'some instance field value', '`this` is correctly bound datasource instance methods')
       }
     }, {
       data: 'test'


### PR DESCRIPTION
After trying out datasources for the first time I found that `this` in DataSource instance methods were not what I expected.