### PR TITLE
forward-porting some recent changes and a bug fix

### DIFF
--- a/.nycrc
+++ b/.nycrc
@@ -3,5 +3,8 @@
   "statements": 80,
   "branches": 80,
   "functions": 80,
-  "lines": 80
+  "lines": 80,
+  "exclude": [
+    "**/__tests__.js"
+  ]
 }

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ To intercept resolvers with mocks execute this app with `GRAPHQL_MOCK=1` enabled
   - `context` - an optional object { namespace, factory } for contributing to context.
   - `directives` - an optional object containing custom schema directives.
   - `useMocks` - enable mocks.
-  - `preserveMockResolvers` - preserve type resolvers in mock mode.
+  - `preserveResolvers` - dont replace provided atual resolvers with mocks (custom or default), enables mocking parts of a schema
   - `mocks` - an optional object containing mock types.
   - `dataSources` - an array of data sources instances to make available on `context.dataSources` .
   - `dataSourceOverrides` - overrides for data sources in the component tree.
@@ -47,7 +47,7 @@ To intercept resolvers with mocks execute this app with `GRAPHQL_MOCK=1` enabled
   - `options` - additional options:
     - `subPath` - optional subPath to extract sub-query from
     - `contextValue` - the context (required).
-    - `info` - the info object (required).
+    - `info` - the info object from the calling resolver (required).
 
 A new GraphQLComponent instance has the following API:
 

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ To intercept resolvers with mocks execute this app with `GRAPHQL_MOCK=1` enabled
   - `context` - an optional object { namespace, factory } for contributing to context.
   - `directives` - an optional object containing custom schema directives.
   - `useMocks` - enable mocks.
-  - `preserveResolvers` - dont replace provided atual resolvers with mocks (custom or default), enables mocking parts of a schema
+  - `preserveResolvers` - dont replace provided actual resolvers with mocks (custom or default), enables mocking parts of a schema
   - `mocks` - an optional object containing mock types.
   - `dataSources` - an array of data sources instances to make available on `context.dataSources` .
   - `dataSourceOverrides` - overrides for data sources in the component tree.

--- a/lib/__tests__.js
+++ b/lib/__tests__.js
@@ -65,7 +65,7 @@ Test('component resolver delegate', async (t) => {
     ]
   });
 
-  const { data, errors } = await graphql.execute({
+  const { data } = await graphql.execute({
     document: gql`query { test { value } }`,
     schema: component.schema,
     rootValue: undefined,
@@ -264,7 +264,7 @@ Test('delegateToComponent from type resolver', async (t) => {
     `,
     resolvers: {
       Query: {
-        parent: async function (_, args, context, info) {
+        parent: async function () {
           return {};
         }
       },
@@ -379,16 +379,16 @@ Test.skip('FIXME test component mocks', (t) => {
       }
     `;
 
-    const { data, errors } = await graphql.execute({
+    const { data } = await graphql.execute({
       document,
-      schema: component.schema,
+      schema: componentC.schema,
       rootValue: undefined,
       contextValue: {}
     });
 
-    t.equal(result.a.value, 'a', 'returns Component A\'s mock');
-    t.equal(result.b.value, 'b', 'returns Component B\'s mock');
-    t.equal(result.c.value, 'c', 'returns Component C\'s mock');
+    t.equal(data.a.value, 'a', 'returns Component A\'s mock');
+    t.equal(data.b.value, 'b', 'returns Component B\'s mock');
+    t.equal(data.c.value, 'c', 'returns Component C\'s mock');
   });
 });
 
@@ -421,7 +421,7 @@ Test('federated schema', (t) => {
     ],
     resolvers: {
       Query: {
-        property(_, { id }, context, info) {
+        property(_, { id }) {
           return {
             id,
             geo: ['lat', 'long']
@@ -429,7 +429,7 @@ Test('federated schema', (t) => {
         }
       },
       Property: {
-        __resolveReference(property, context) {
+        __resolveReference() {
 
         }
       }
@@ -473,7 +473,7 @@ Test('integration: data source', (t) => {
         t.equal(args[0].data, 'test', 'injected the right data');
         t.equal(args[1], 'test', 'data still passed to original call');
       }
-    };
+    }
 
     const { context } = new GraphQLComponent({
       dataSources: [new DataSource()]

--- a/lib/__tests__.js
+++ b/lib/__tests__.js
@@ -2,7 +2,7 @@
 
 const Test = require('tape');
 const gql = require('graphql-tag');
-const { SchemaDirectiveVisitor } = require('apollo-server');
+const { SchemaDirectiveVisitor } = require('@graphql-tools/utils');
 const graphql = require('graphql');
 const GraphQLComponent = require('./index');
 

--- a/lib/__tests__.js
+++ b/lib/__tests__.js
@@ -318,8 +318,7 @@ Test('delegateToComponent from type resolver', async (t) => {
   t.deepEqual(parent2, { child: { anotherChildField: 'Another Child Field', addedField: 'Added from Parent' }}, 'received correct second result');
 });
 
-Test.skip('FIXME test component mocks', (t) => {
-  t.test('imported mocks', async (t) => {
+Test('mocks', async (t) => {
     t.plan(3);
 
     const componentA = new GraphQLComponent({
@@ -331,9 +330,9 @@ Test.skip('FIXME test component mocks', (t) => {
           a: A
         }
       `],
-      mocks: () => ({
+      mocks: {
         A: () => ({ value: 'a' })
-      })
+      }
     });
 
     const componentB = new GraphQLComponent({
@@ -348,9 +347,9 @@ Test.skip('FIXME test component mocks', (t) => {
       imports: [
         componentA
       ],
-      mocks: () => ({
+      mocks: {
         B: () => ({ value: 'b' })
-      })
+      }
     });
 
     const componentC = new GraphQLComponent({
@@ -365,9 +364,9 @@ Test.skip('FIXME test component mocks', (t) => {
       imports: [
         componentB
       ],
-      mocks: () => ({
+      mocks: {
         C: () => ({ value: 'c' })
-      }),
+      },
       useMocks: true
     });
 
@@ -389,7 +388,6 @@ Test.skip('FIXME test component mocks', (t) => {
     t.equal(data.a.value, 'a', 'returns Component A\'s mock');
     t.equal(data.b.value, 'b', 'returns Component B\'s mock');
     t.equal(data.c.value, 'c', 'returns Component C\'s mock');
-  });
 });
 
 Test('federated schema', (t) => {

--- a/lib/__tests__.js
+++ b/lib/__tests__.js
@@ -485,3 +485,138 @@ Test('integration: data source', (t) => {
   });
   
 });
+
+Test('proxy to child with root query that returns interface type (using __resolveType())', async (t) => {
+  const child = new GraphQLComponent({
+    types: `
+      type Query {
+        things: [Thing]
+      }
+      interface Thing {
+        id: ID
+      }
+      type Person implements Thing {
+        id: ID
+        name: String
+      }
+      type Animal implements Thing {
+        id: ID
+        someField: Int
+      }
+    `,
+    resolvers: {
+      Query: {
+        things() {
+          return [
+            {
+              id: '1',
+              name: 'Joe Smith'
+            }
+          ]
+        }
+      },
+      Thing: {
+        __resolveType(parent) {
+          console.log('called');
+          if (parent.name) {
+            return 'Person';
+          }
+          return 'Animal';
+        }
+      }
+    }
+  });
+
+  const parent = new GraphQLComponent({
+    imports: [
+      child
+    ]
+  });
+
+  const result = await graphql.execute({
+    document: gql`
+      query {
+        things {
+          id
+          ... on Person {
+            name
+          }
+        }
+      }
+    `,
+    schema: parent.schema,
+    contextValue: {}
+  });
+
+  t.deepEquals(result.data.things, [{ id: '1', name: 'Joe Smith' }], 'interface type resolved')
+  t.notOk(result.errors, 'no errors');
+  t.end();
+});
+
+Test('proxy to child with root query that returns interface type (using __isTypeOf())', async (t) => {
+  const child = new GraphQLComponent({
+    types: `
+      type Query {
+        things: [Thing]
+      }
+      interface Thing {
+        id: ID
+      }
+      type Person implements Thing {
+        id: ID
+        name: String
+      }
+      type Animal implements Thing {
+        id: ID
+        someField: Int
+      }
+    `,
+    resolvers: {
+      Query: {
+        things() {
+          return [
+            {
+              id: '1',
+              name: 'Joe Smith'
+            }
+          ]
+        }
+      },
+      Person: {
+        __isTypeOf() {
+          return 'Person'
+        }
+      },
+      Animal: {
+        __isTypeOf() {
+          return 'Animal';
+        }
+      }
+    }
+  });
+
+  const parent = new GraphQLComponent({
+    imports: [
+      child
+    ]
+  });
+
+  const result = await graphql.execute({
+    document: gql`
+      query {
+        things {
+          id
+          ... on Person {
+            name
+          }
+        }
+      }
+    `,
+    schema: parent.schema,
+    contextValue: {}
+  });
+
+  t.deepEquals(result.data.things, [{ id: '1', name: 'Joe Smith' }], 'interface type resolved')
+  t.notOk(result.errors, 'no errors');
+  t.end();
+});

--- a/lib/datasource/__tests__.js
+++ b/lib/datasource/__tests__.js
@@ -2,7 +2,6 @@
 
 const Test = require('tape');
 const { intercept, createDataSourceInjection } = require('./index');
-const GraphQLComponent = require('../index');
 
 Test('intercepts', (t) => {
 
@@ -72,7 +71,7 @@ Test('injection', (t) => {
         t.equal(args[0].data, 'test', 'injected the right data');
         t.equal(args[1], 'test', 'data still passed to original call');
       }
-    };
+    }
 
     const component = {
       dataSources: [new DataSource()],
@@ -102,7 +101,7 @@ Test('injection', (t) => {
         t.equal(args[0].data, 'test', 'injected the right data');
         t.equal(args[1], 'test', 'data still passed to original call');
       }
-    };
+    }
 
     const component = {
       dataSources: [new class Default {

--- a/lib/imports/__tests__.js
+++ b/lib/imports/__tests__.js
@@ -1,7 +1,8 @@
 'use strict';
 
 const Test = require('tape');
-const { buildDependencyTree, filterTypes, namespaceDirectives } = require('./index');
+// TODO: test namespaceDirectives
+const { buildDependencyTree, filterTypes, /*namespaceDirectives*/ } = require('./index');
 const { buildASTSchema } = require('graphql');
 const Gql = require('graphql-tag')
 

--- a/lib/imports/index.js
+++ b/lib/imports/index.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const graphql = require('graphql');
-const { createProxyResolvers, transformResolvers } = require('../resolvers');
+const { createProxyResolvers, transformResolvers, getAbstractNonRootTypeResolvers } = require('../resolvers');
 
 const debug = require('debug')('graphql-component:imports');
 
@@ -111,6 +111,10 @@ const buildDependencyTree = function (root) {
     const resolvers = createProxyResolvers(component, transformResolvers(component.resolvers, excludes));
 
     mergedResolvers.push(resolvers);
+
+    // FIXME: pull up abstract non root type resolvers (such as __resolveType) from imports to avoid the parent schema not having a __resolveType function - this still results in the "double execution" problem we used to see with non-root type resolvers being pulled up but is a tradeoff that favors simplicity in a complex situation (delegating execution to components whose root type fields return an Abstract type)
+    const abstractNonRootTypeResolvers = getAbstractNonRootTypeResolvers(component);
+    mergedResolvers.push(abstractNonRootTypeResolvers);
 
     visited.add(component.id);
     queue.push(...component.imports.map((imported) => ({ ...imported, parent: component })));

--- a/lib/imports/index.js
+++ b/lib/imports/index.js
@@ -83,6 +83,7 @@ const namespaceDirectives = function (rootDirectives, id, document) {
 const buildDependencyTree = function (root) {
   const mergedTypes = [];
   const mergedResolvers = [];
+  const mergedMocks = [];
 
   const visited = new Set();
   const queue = [...root.imports.map((imported) => ({ ...imported, parent: root }))]; 
@@ -105,6 +106,7 @@ const buildDependencyTree = function (root) {
     }), excludes);
 
     mergedTypes.push(...types);
+    mergedMocks.push(component.mocks);
 
     const resolvers = createProxyResolvers(component, transformResolvers(component.resolvers, excludes));
 
@@ -114,7 +116,7 @@ const buildDependencyTree = function (root) {
     queue.push(...component.imports.map((imported) => ({ ...imported, parent: component })));
   }
 
-  return { mergedTypes, mergedResolvers };
+  return { mergedTypes, mergedResolvers, mergedMocks };
 };
 
 module.exports = { buildDependencyTree, filterTypes, namespaceDirectives };

--- a/lib/imports/index.js
+++ b/lib/imports/index.js
@@ -114,8 +114,10 @@ const buildDependencyTree = function (root) {
 
     // FIXME: pull up abstract non root type resolvers (such as __resolveType) from imports to avoid the parent schema not having a __resolveType function - this still results in the "double execution" problem we used to see with non-root type resolvers being pulled up but is a tradeoff that favors simplicity in a complex situation (delegating execution to components whose root type fields return an Abstract type)
     const abstractNonRootTypeResolvers = getAbstractNonRootTypeResolvers(component);
-    mergedResolvers.push(abstractNonRootTypeResolvers);
-
+    if (Object.keys(abstractNonRootTypeResolvers).length > 0) {
+      mergedResolvers.push(abstractNonRootTypeResolvers);
+    }
+    
     visited.add(component.id);
     queue.push(...component.imports.map((imported) => ({ ...imported, parent: component })));
   }

--- a/lib/index.js
+++ b/lib/index.js
@@ -93,7 +93,7 @@ class GraphQLComponent {
       return this._schema;
     }
 
-    const { mergedTypes, mergedResolvers } = buildDependencyTree(this);
+    const { mergedTypes, mergedResolvers, mergedMocks } = buildDependencyTree(this);
 
     const typeDefs = mergeTypeDefs([...mergedTypes, ...this._types.map((type) => graphql.parse(type))]);
     const resolvers = mergeResolvers([...mergedResolvers, this._resolvers]);
@@ -101,18 +101,18 @@ class GraphQLComponent {
 
     const makeSchema = this._federation ? this.makeFederatedSchemaWithDirectives : makeExecutableSchema;
 
-    const schema = makeSchema({
+    let schema = makeSchema({
       typeDefs,
       resolvers,
       schemaDirectives
     });
 
-    debug(`created ${this.constructor.name} schema`);
+    debug(`created ${this.name} schema`);
 
     if (this._useMocks) {
       debug(`adding mocks, preserveResolvers=${this._preserveResolvers}`);
 
-      addMocksToSchema({ schema, mocks: this._mocks, preserveResolvers: this._preserveResolvers });
+      schema = addMocksToSchema({schema, mocks: Object.assign({}, this._mocks, ...mergedMocks), preserveResolvers: this._preserveResolvers});
     }
 
     this._schema = schema;

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,16 +1,16 @@
 'use strict';
 
 const graphql = require('graphql');
-const gql = require('graphql-tag');
 const { buildFederatedSchema } = require('@apollo/federation');
-const { makeExecutableSchema, addMockFunctionsToSchema, SchemaDirectiveVisitor } = require('graphql-tools');
-const { mergeResolvers, mergeTypeDefs } = require('graphql-toolkit');
+const { mergeResolvers, mergeTypeDefs } = require('@graphql-tools/merge');
+const { makeExecutableSchema } = require('@graphql-tools/schema');
+const { addMocksToSchema } = require('@graphql-tools/mock');
+const { SchemaDirectiveVisitor } = require('@graphql-tools/utils');
 const { wrapResolvers, delegateToComponent } = require('./resolvers');
 const { buildDependencyTree } = require('./imports');
 const { wrapContext, createContext } = require('./context');
 const { createDataSourceInjection } = require('./datasource');
 const cuid = require('cuid');
-const deepSet = require('lodash.set');
 
 const debug = require('debug')('graphql-component:schema');
 
@@ -112,7 +112,7 @@ class GraphQLComponent {
     if (this._useMocks) {
       debug(`adding mocks, preserveResolvers=${this._preserveResolvers}`);
 
-      addMockFunctionsToSchema({ schema, mocks: this._mocks, preserveResolvers: this._preserveResolvers });
+      addMocksToSchema({ schema, mocks: this._mocks, preserveResolvers: this._preserveResolvers });
     }
 
     this._schema = schema;

--- a/lib/resolvers/__tests__.js
+++ b/lib/resolvers/__tests__.js
@@ -1,14 +1,258 @@
 'use strict';
 
 const Test = require('tape');
-const { memoize, transformResolvers, wrapResolvers, createProxyResolvers, createProxyResolver, createOperationForField } = require('./index');
+const { GraphQLScalarType } = require('graphql');
+const {
+  memoize,
+  transformResolvers,
+  wrapResolvers,
+  createProxyResolver,
+  createProxyResolvers,
+} = require('./index');
 
-Test('wrapping', (t) => {
+Test('memoize()', (t) => {
+  t.test('memoize() a resolver function', (st) => {
+    let resolverRunCount = 0;
 
-  t.test('wrap Query resolver function', (t) => {
+    const resolverToMemoize = function () {
+      resolverRunCount += 1;
+      return resolverRunCount;
+    };
 
-    t.plan(1);
+    const memoizedResolver = memoize('Query', 'test', resolverToMemoize);
 
+    const parent = {};
+    const args = {};
+    const context = {};
+    const info = {
+      path: {
+        key: 'test'
+      }
+    }
+
+    let callCount = memoizedResolver(parent, args, context, info);
+
+    st.equal(callCount, 1, 'first call of memoized resolver returns expected value');
+
+    callCount = memoizedResolver(parent, args, context, info);
+
+    st.equal(callCount, 1, 'second call of memoizedResolver function doesnt call underlying resolver');
+    st.end();
+  });
+
+  t.test('memoize() with different operation aliases', (st) => {
+    let resolverRunCount = 0;
+
+    const resolverToMemoize = function () {
+      resolverRunCount += 1;
+      return resolverRunCount;
+    };
+
+    const memoizedResolver = memoize('Query', 'test', resolverToMemoize);
+
+    const parent = {};
+    const args = {};
+    const context = {};
+    const infoWithAlias1 = { path: { key: 'alias1' } };
+    const infoWithAlias2 = { path: { key: 'alias2' } };
+
+    let callCount = memoizedResolver(parent, args, context, infoWithAlias1);
+
+    st.equal(callCount, 1, 'first call returns expected call count of 1');
+
+    callCount = memoizedResolver(parent, args, context, infoWithAlias2);
+
+    st.equal(callCount, 2, 'second call of same resolver with different alias results in cache miss and call count 2');
+    st.end();
+  });
+
+  t.test('memoize() with different context', (st) => {
+    let resolverRunCount = 0;
+
+    const resolverToMemoize = function () {
+      resolverRunCount += 1;
+      return resolverRunCount;
+    };
+
+    const memoizedResolver = memoize('Query', 'test', resolverToMemoize);
+
+    const parent = {};
+    const args = {};
+    let context = {};
+    const info = { path: { key: 'test'} };
+
+    let callCount = memoizedResolver(parent, args, context, info);
+
+    st.equal(callCount, 1, 'first call returns expected call count of 1');
+
+    callCount = memoizedResolver(parent, args, context, info);
+
+    st.equal(callCount, 1, 'second call with same context returns expected call count of 1');
+
+    // set context to a new reference
+    context = {};
+    callCount = memoizedResolver(parent, args, context, info);
+
+    st.equal(callCount, 2, 'third call with different context results in cache miss and expected call count 2');
+    st.end();
+  });
+
+  t.test('memoize() with different args', (st) => {
+    let resolverRunCount = 0;
+
+    const resolverToMemoize = function () {
+      resolverRunCount += 1;
+      return resolverRunCount;
+    };
+
+    const memoizedResolver = memoize('Query', 'test', resolverToMemoize);
+
+    const parent = {};
+    const args = {};
+    const context = {};
+    const info = { path: { key: 'test'} };
+
+    let callCount = memoizedResolver(parent, args, context, info);
+
+    st.equal(callCount, 1, 'first call returns expected call count of 1');
+
+    args.foo = 'bar';
+    callCount = memoizedResolver(parent, args, context, info);
+
+    st.equal(callCount, 2, 'second call with different args results in cache miss and expected call count 2');
+    st.end();
+  });
+});
+
+Test('transformResolvers()', (t) => {
+  t.test('exclusions argument is undefined', (st) => {
+    const resolvers = {
+      Query: {
+        foo() { }
+      }
+    }
+    const transformedResolvers = transformResolvers(resolvers);
+    st.equal(transformedResolvers, resolvers, 'object reference returned from transformResolvers is equal to input reference');
+    st.deepEqual(transformedResolvers, resolvers, 'object content returned from transformResolver is equal to input resolver object content');
+    st.end();
+  });
+
+  t.test('exclusions argument is an empty array', (st) => {
+    const resolvers = {
+      Query: {
+        foo() { }
+      }
+    }
+    const transformedResolvers = transformResolvers(resolvers, []);
+    st.equal(transformedResolvers, resolvers, 'object reference returned from transformResolvers is equal to input reference');
+    st.deepEqual(transformedResolvers, resolvers, 'object content returned from transformResolver is equal to input resolver object content');
+    st.end();
+  });
+
+  t.test(`exclude all types via '*'`, (st) => {
+    const resolvers = {
+      Query: {
+        foo() {}
+      },
+      Mutation: {
+        baz() {}
+      },
+      SomeType: {
+        bar() {}
+      }
+    };
+
+    const transformedResolvers = transformResolvers(resolvers, [['*']]);
+    st.deepEqual(transformedResolvers, {}, 'results in an empty resolver map being returned');
+    st.end();
+  });
+
+  t.test(`exclude a entire type by specifying 'Type' exclusion)`, (st) => {
+    const resolvers = {
+      Query: {
+        foo() {}
+      },
+      SomeType: {
+        bar() {}
+      }
+    };
+
+    const transformedResolvers = transformResolvers(resolvers, [['SomeType']]);
+    st.notOk(transformedResolvers.SomeType, 'entire specified type is excluded');
+    st.ok(transformedResolvers.Query.foo, 'other non-excluded type remains');
+    st.end();
+  });
+
+  t.test(`exclude an entire type by specifying 'Type.' exclusion`, (st) => {
+    const resolvers = {
+      Query: {
+        foo() {}
+      },
+      SomeType: {
+        bar() {}
+      }
+    };
+
+    const transformedResolvers = transformResolvers(resolvers, [['SomeType', '']]);
+    st.notOk(transformedResolvers.SomeType,'entire specified type is excluded');
+    st.ok(transformedResolvers.Query.foo, 'other non-excluded type remains');
+    st.end();
+  });
+
+  t.test(`exclude an entire type by specifying 'Type.*' exclusion`, (st) => {
+    const resolvers = {
+      Query: {
+        foo() {}
+      },
+      SomeType: {
+        bar() {}
+      }
+    };
+
+    const transformedResolvers = transformResolvers(resolvers, [['SomeType', '*']]);
+    st.notOk(transformedResolvers.SomeType, 'entire specified type is excluded');
+    st.ok(transformedResolvers.Query.foo, 'other non-excluded type remains');
+    st.end();
+  });
+
+  t.test(`exclude an individual field on a type`, (st) => {
+    const resolvers = {
+      Query: {
+        foo() {}
+      },
+      SomeType: {
+        bar() {},
+        a() {}
+      }
+    };
+
+    const transformedResolvers = transformResolvers(resolvers, [['SomeType', 'bar']]);
+    st.notOk(transformedResolvers.SomeType.bar, 'specified field on specified type is removed');
+    st.ok(transformedResolvers.SomeType.a, 'non-excluded field on specified type remains');
+    st.ok(transformedResolvers.Query.foo, 'non-exluded type remains');
+    st.end();
+  });
+
+  t.test('exclude all fields on a type via 1 by 1 exclusion', (st) => {
+    const resolvers = {
+      Query: {
+        foo() {}
+      },
+      SomeType: {
+        bar() {},
+        a() {}
+      }
+    };
+
+    const transformedResolvers = transformResolvers(resolvers, [['SomeType', 'bar'], ['SomeType', 'a']]);
+    st.notOk(transformedResolvers.SomeType, 'specified type is completely removed because all of its fields were removed');
+    st.ok(transformedResolvers.Query.foo, 'non-exluded type remains');
+    st.end();
+  })
+});
+
+Test('wrapResolvers()', (t) => {
+  t.test('wrap Query field resolver function', (st) => {
     const resolvers = {
       Query: {
         test() {
@@ -21,13 +265,11 @@ Test('wrapping', (t) => {
 
     const value = wrapped.Query.test({}, {}, {}, { parentType: 'Query', path: { key: 'test' } });
 
-    t.equal(value, 1, 'Query resolver was bound');
+    st.equal(value, 1, 'Query field resolver is bound');
+    st.end();
   });
 
-  t.test('wrap Mutation resolver function', (t) => {
-
-    t.plan(1);
-
+  t.test('wrap Mutation field resolver function', (st) => {
     const resolvers = {
       Mutation: {
         test() {
@@ -37,18 +279,19 @@ Test('wrapping', (t) => {
     };
 
     const wrapped = wrapResolvers({ id: 1 }, resolvers);
+
     const value = wrapped.Mutation.test({}, {}, {}, { parentType: 'Mutation', path: { key: 'test' } });
 
-    t.equal(value, 1, 'Mutation resolver was bound');
+    st.equal(value, 1, 'Mutation field resolver is bound');
+    st.end();
   });
 
-  t.test('wrap Subscription resolver object', (t) => {
-    t.plan(1);
+  t.test('wrap Subscription field resolver object', (st) => {
 
     const resolvers = {
       Subscription: {
         someSub: {
-          subscribe: () => { t.equal(this.id, undefined, 'subscription subscribe() resolver was not bound to the wrapResolvers input object containing an id field')}
+          subscribe: () => { st.notOk(this.id, 'subscription subscribe() resolver was not bound')}
         }
       }
     };
@@ -56,11 +299,10 @@ Test('wrapping', (t) => {
     const wrapped = wrapResolvers({ id: 1 }, resolvers);
     // call the wrapped resolver result to assert this test case
     wrapped.Subscription.someSub.subscribe();
+    st.end();
   });
 
-  t.test('wrap resolver mapped to primitive (enum remap)', (t) => {
-    t.plan(1);
-
+  t.test('wrap an enum remap', (st) => {
     const resolvers = {
       FooBarEnumType: {
         FOO: 1,
@@ -69,248 +311,67 @@ Test('wrapping', (t) => {
     }
 
     const wrapped = wrapResolvers({id: 1}, resolvers);
-    t.equal(wrapped.FooBarEnumType.FOO, 1, 'primitive resolver mapping wraps without error and returns primitive')
+    st.equal(wrapped.FooBarEnumType.FOO, 1, 'enum remap runs through wrapResolvers() without error, left as is');
+    st.end();
   });
 
-  t.test('memoized resolvers', (t) => {
-
-    t.plan(2);
-
-    let ran = 0;
-
+  t.test('wrap non root type field resolver', (st) => {
     const resolvers = {
-      Query: {
+      SomeType: {
         test() {
-          ran += 1;
-          return ran;
+          return this.id;
         }
       }
     };
 
-    const wrapped = wrapResolvers(undefined, resolvers);
+    const wrapped = wrapResolvers({ id: 1 }, resolvers);
 
-    const ctx = {};
-    const info = { parentType: 'Query', path: { key: 'test' } };
+    const value = wrapped.SomeType.test({}, {}, {}, { parentType: 'SomeType', path: { key: 'test' } });
 
-    let value = wrapped.Query.test({}, {}, ctx, info);
-
-    t.equal(value, 1, 'expected value');
-
-    value = wrapped.Query.test({}, {}, ctx, info);
-
-    t.equal(value, 1, 'same value, only ran resolver once');
+    st.equal(value, 1, 'SomeType field resolver is bound');
+    st.end();
   });
 
-});
-
-Test('memoize resolver', (t) => {
-
-  t.test('memoized', (t) => {
-    t.plan(2);
-
-    let ran = 0;
-
-    const resolver = function () {
-      ran += 1;
-      return ran;
-    };
-
-    const wrapped = memoize('Query', 'test', resolver);
-
-    const ctx = {};
-
-    let value = wrapped({}, {}, ctx, { path: { key: 'test' } });
-
-    t.equal(value, 1, 'expected value');
-
-    value = wrapped({}, {}, ctx, { path: { key: 'test' } });
-
-    t.equal(value, 1, 'same value, only ran resolver once');
-  });
-
-  t.test('miss on different alias', (t) => {
-    t.plan(2);
-
-    let ran = 0;
-
-    const resolver = function () {
-      ran += 1;
-      return ran;
-    };
-
-    const wrapped = memoize('Query', 'test', resolver);
-
-    const ctx = {};
-
-    let value = wrapped({}, {}, ctx, { path: { key: 'alias1' }});
-
-    t.equal(value, 1, 'expected value');
-
-    value = wrapped({}, {}, ctx, { path: { key: 'alias2' }});
-
-    t.equal(value, 2, 'different value due to different alias');
-  });
-
-  t.test('miss on different context', (t) => {
-    t.plan(3);
-
-    let ran = 0;
-
-    const resolver = function () {
-      ran += 1;
-      return ran;
-    };
-
-    const wrapped = memoize('Query', 'test', resolver);
-
-    const ctx = {};
-
-    let value = wrapped({}, {}, ctx, { path: { key: 'test' } });
-
-    t.equal(value, 1, 'expected value');
-
-    value = wrapped({}, {}, ctx, { path: { key: 'test' } });
-
-    t.equal(value, 1, 'same value, only ran resolver once');
-
-    value = wrapped({}, {}, {}, { path: { key: 'test' } });
-
-    t.equal(value, 2, 'different value, different context');
-  });
-
-  t.test('miss on different args', (t) => {
-    t.plan(2);
-
-    let ran = 0;
-
-    const resolver = function () {
-      ran += 1;
-      return ran;
-    };
-
-    const wrapped = memoize('Query', 'test', resolver);
-
-    const ctx = {};
-
-    let value = wrapped({}, { foo: 1 }, ctx, { path: { key: 'test' } });
-
-    t.equal(value, 1, 'expected value');
-
-    value = wrapped({}, { foo: 2 }, ctx, { path: { key: 'test' } });
-
-    t.equal(value, 2, 'different value');
-  });
-
-});
-
-Test('transform', (t) => {
-
-  t.test('exclude wildcard', (t) => {
-    t.plan(2);
-
+  t.test('wrap a custom GraphQLScalarType resolver', (st) => {
+    const CustomScalarType = new GraphQLScalarType({
+      name: 'CustomScalarType',
+      description: 'foo bar custom scalar type',
+      serialize() {},
+      parseValue() {},
+      parseLiteral() {}
+    })
     const resolvers = {
       Query: {
-        test: () => {}
+        foo() {}
       },
-      Mutation: {
-        test: () => {}
+      CustomScalarType
+    };
+    const wrapped = wrapResolvers({ id: 1}, resolvers);
+    st.equal(wrapped.CustomScalarType, CustomScalarType, 'wrapped reference is equal to original reference (returned as is)');
+    st.end();
+  });
+});
+
+Test('createProxyResolver()', (t) => {
+  const resolver = createProxyResolver(undefined, 'Query', 'test');
+  t.strictEqual(resolver.__isProxy, true, 'function returned is a proxy');
+  t.end();
+});
+
+Test('createProxyResolvers()', (t) => {
+  t.test('resolver map passed to createProxyResolvers()', (st) => {
+    const resolvers = {
+      Query: {
+        foo() { }
+      },
+      Foo: {
+        bar() { }
       }
     };
-
-    const transformed = transformResolvers(resolvers, [['Mutation', '*']]);
-
-    t.ok(transformed.Query && transformed.Query.test, 'query present');
-    t.ok(!transformed.Mutation, 'mutation not present');
-
+  
+    const proxiedResolvers = createProxyResolvers(undefined, resolvers);
+    st.ok(proxiedResolvers.Query.foo.__isProxy, 'root type field resolver is a proxy');
+    st.notOk(proxiedResolvers.Foo, `non root type isn't returned with proxied resolver map`);
+    st.end();
   });
-
-});
-
-Test.skip('transform and proxyImportedResolvers=true', (t) => {
-
-  // t.test('exclude wildcard', (t) => {
-  //   t.plan(4);
-
-  //   const imp = {
-  //     _resolvers: {
-  //       Query: {
-  //         test() {
-  //           return true;
-  //         }
-  //       }
-  //     },
-  //     _importedResolvers: {
-  //       Query: {
-  //         imported() {
-  //           return true;
-  //         }
-  //       }
-  //     }
-  //   };
-
-  //   const imported = getImportedResolvers(imp, true);
-
-  //   const transformed = transformResolvers(imported, [['Mutation', '*']]);
-  //   t.ok(transformed.Query.test.__isProxy, 'resolver is proxy');
-  //   t.ok(transformed.Query.imported.__isProxy, 'transitive resolver is proxy');
-  //   t.ok(transformed.Query && transformed.Query.test, 'query present');
-  //   t.ok(!transformed.Mutation, 'mutation not present');
-
-  // });
-
-});
-
-Test.skip('transform and proxyImportedResolvers=false', (t) => {
-
-  // t.test('exclude wildcard', (t) => {
-  //   t.plan(3);
-
-  //   const imp = {
-  //     _resolvers: {
-  //       Query: {
-  //         test() {
-  //           return true;
-  //         }
-  //       }
-  //     },
-  //     _importedResolvers: {
-  //       Query: {
-  //         imported() {
-  //           return true;
-  //         }
-  //       }
-  //     }
-  //   };
-
-  //   const imported = getImportedResolvers(imp, false);
-
-  //   const transformed = transformResolvers(imported, [['Mutation', '*']]);
-  //   t.ok(!transformed.Query.test.__isProxy, 'resolver is not proxy');
-  //   t.ok(transformed.Query && transformed.Query.test, 'query present');
-  //   t.ok(!transformed.Mutation, 'mutation not present');
-
-  // });
-
-});
-
-Test('proxy resolvers', (t) => {
-
-  t.test('createProxyResolver', (t) => {
-    t.plan(1);
-
-    const resolver = createProxyResolver(undefined, 'Query', 'test');
-
-    t.strictEqual(resolver.__isProxy, true, 'function created is a proxy');
-  });
-
-  t.test('createProxyResolvers', (t) => {
-    t.plan(2);
-
-    const resolvers = createProxyResolvers(undefined, { Query: { test() {} }, Test: { field() {} } });
-
-    t.ok(resolvers.Query, 'included root resolvers');
-    t.ok(!resolvers.Test, 'did not include type resolvers');
-
-  });
-
 });

--- a/lib/resolvers/index.js
+++ b/lib/resolvers/index.js
@@ -293,4 +293,34 @@ const createProxyResolvers = function (component, resolvers) {
   return proxyResolvers;
 };
 
-module.exports = { memoize, transformResolvers, wrapResolvers, createProxyResolvers, createProxyResolver, delegateToComponent };
+/**
+ * helper to extract abstract non-root type resolvers (such as __resolveType) from a component's 
+ * resolver
+ * @param {*} component 
+ */
+const getAbstractNonRootTypeResolvers = function (component) {
+  const abstractNonRootTypeResolvers = {};
+  const iterateNonRootTypeResolvers = function* () {
+    for (const type of Object.keys(component.resolvers)) {
+      if (['Query', 'Mutation', 'Subscription'].indexOf(type) === -1) {
+        yield [type, component.resolvers[type]];
+      }
+    }
+  };
+
+  for (const [nonRootType, fieldResolvers] of iterateNonRootTypeResolvers()) {
+    if (abstractNonRootTypeResolvers[nonRootType] === undefined) {
+      abstractNonRootTypeResolvers[nonRootType] = {};
+    }
+
+    for (const [field, resolver] of Object.entries(fieldResolvers)) {
+      if (field.startsWith('__')) {
+        abstractNonRootTypeResolvers[nonRootType][field] = resolver;
+      }
+    }
+  }
+
+  return abstractNonRootTypeResolvers;
+}
+
+module.exports = { memoize, transformResolvers, wrapResolvers, createProxyResolvers, createProxyResolver, getAbstractNonRootTypeResolvers, delegateToComponent };

--- a/lib/resolvers/index.js
+++ b/lib/resolvers/index.js
@@ -4,6 +4,18 @@ const debug = require('debug')('graphql-component:resolver');
 const { GraphQLScalarType, Kind, execute } = require('graphql');
 const deepSet = require('lodash.set');
 
+/**
+ * memoizes resolver functions such that calls of an identical resolver (args/context/path) within the same request context are avoided
+ * @param {string} parentType - the type whose field resolver is being 
+ * wrapped/memoized
+ * @param {string} fieldName -  the field on the parentType whose resolver 
+ * function is being wrapped/memoized
+ * @param {function} resolve - the resolver function that parentType.
+ * fieldName is mapped to
+ * @returns {function} a function that wraps the input resolver function and
+ * whose closure scope contains a WeakMap to achieve memoization of the wrapped 
+ * input resolver function
+ */
 const memoize = function (parentType, fieldName, resolve) {
   const _cache = new WeakMap();
 
@@ -36,6 +48,16 @@ const memoize = function (parentType, fieldName, resolve) {
   };
 };
 
+/**
+ * excludes types and/or fields on types from an input resolver map. mainly used
+ * to exclude root type resolvers from imported resolver maps
+ * @param {Object} resolvers - the resolver map to be transformed
+ * @param {Array<string>} excludes - an array of exclusions in the general form 
+ * of "type.field". This format supports excluding all types ('*'), an entire 
+ * type and the fields it encloses ('type', 'type.', 'type.*'), and individual 
+ * fields on a type ('type.somefield').
+ * @returns {Object} - a new resolver map with the applied exclusions
+ */
 const transformResolvers = function (resolvers, excludes) {
   if (!excludes || excludes.length < 1) {
     return resolvers;
@@ -43,52 +65,72 @@ const transformResolvers = function (resolvers, excludes) {
 
   let filteredResolvers = Object.assign({}, resolvers);
 
-  for (const [root, name] of excludes) {
-    if (root === '*') {
+  for (const [type, field] of excludes) {
+    if (type === '*') {
       filteredResolvers = {};
       break;
     }
-    if (!name || name === '' || name === '*') {
-      delete filteredResolvers[root];
+    if (!field || field === '' || field === '*') {
+      delete filteredResolvers[type];
       continue;
     }
-    delete filteredResolvers[root][name];
+    delete filteredResolvers[type][field];
+    // covers the case where all fields of a type were specified 1 by 1, which
+    // should result in the entire type being removed
+    if (Object.keys(filteredResolvers[type]).length === 0) {
+      delete filteredResolvers[type];
+    }
   }
 
   return filteredResolvers;
 };
 
+/**
+ * binds an object context to resolver functions in the input resolver map
+ * @param {Object} bind - the object context to bind to resolver functions
+ * @param {Object} resolvers - the resolver map containing the resolver 
+ * functions to bind
+ * @returns {Object} - an object identical in structure to the input resolver 
+ * map, except with resolver function bound to the input argument bind
+ */
 const wrapResolvers = function (bind, resolvers = {}) {
   const wrapped = {};
 
-  for (const [name, value] of Object.entries(resolvers)) {
-    if (value instanceof GraphQLScalarType) {
-      wrapped[name] = value;
+  for (const [type, fieldResolvers] of Object.entries(resolvers)) {
+    if (fieldResolvers instanceof GraphQLScalarType) {
+      wrapped[type] = fieldResolvers;
       continue;
     }
 
-    if (!wrapped[name]) {
-      wrapped[name] = {};
+    if (!wrapped[type]) {
+      wrapped[type] = {};
     }
 
-    for (const [resolverName, func] of Object.entries(value)) {
-      if (wrapped[name][resolverName]) {
+    for (const [field, resolverFunc] of Object.entries(fieldResolvers)) {
+      if (wrapped[type][field]) {
         continue;
       }
 
-      if (['Query', 'Mutation'].indexOf(name) > -1) {
-        debug(`memoized ${name}.${resolverName}`);
-        wrapped[name][resolverName] = memoize(name, resolverName, func.bind(bind));
+      if (['Query', 'Mutation'].indexOf(type) > -1) {
+        debug(`memoized ${type}.${field}`);
+        wrapped[type][field] = memoize(type, field, resolverFunc.bind(bind));
       } else {
-        // conditionally bind func since func will not be a function for
-        // Subscriptions and internal enum remapping
-        wrapped[name][resolverName] = typeof func === 'function' ? func.bind(bind) : func;
+        // for types other than Query/Mutation - conditionally bind since in
+        // some cases (Subscriptions and enum remaps) resolverFunc will be 
+        // an object instead of a function
+        wrapped[type][field] = typeof resolverFunc === 'function' ? resolverFunc.bind(bind) : resolverFunc;
       }
     }
   }
   return wrapped;
 };
 
+/**
+ * helper function to extract the so-far traversed path from an info object 
+ * passed to resolvers
+ * @param {Object} info - the info object passed to resolvers
+ * @returns {Array<String>} - the derived path from the input info object
+ */
 const buildPathFromInfo = function (info) {
   const path = [];
   let current = info.path;
@@ -160,7 +202,7 @@ const createSubOperationForField = function (component, fieldPath, info) {
   };
 };
 
-//Eventually accept an argument to map fields for sub-query?
+// Eventually accept an argument to map fields for sub-query?
 const delegateToComponent = async function (component, { subPath, contextValue, info }) {
   const rootPath = buildPathFromInfo(info);
   const fieldPath = subPath !== undefined ? [...rootPath, ...subPath.split('.')] : rootPath;
@@ -190,11 +232,22 @@ const delegateToComponent = async function (component, { subPath, contextValue, 
   return result;
 };
 
-const createProxyResolver = function (component, root, fieldName) {
+/**
+ * returns a proxy function that delegates execution to the input component's 
+ * schema
+ * @param {Object} component - the component to delegate execution to
+ * @param {String} rootType - the root type whose field resolver will be 
+ * executed 
+ * @param {String} fieldName - the root type field whose resolver is proxied
+ * @returns {Function} - a function whose signature is a normal GraphQL 
+ * resolver function but whose implementation delegates execution to the 
+ * component owning the resolver's implementation
+ */
+const createProxyResolver = function (component, rootType, fieldName) {
   const proxyResolver = async function (_, args, contextValue, info) {
-    debug(`delegating ${root}.${fieldName} to ${component.name}`);
+    debug(`delegating ${rootType}.${fieldName} to ${component.name}`);
     
-    const result = await delegateToComponent(component, { contextValue, info});
+    const result = await delegateToComponent(component, { contextValue, info });
     
     return result[info.path.key];
   };
@@ -204,27 +257,36 @@ const createProxyResolver = function (component, root, fieldName) {
   return proxyResolver;
 };
 
+/**
+ * create proxy functions to the input component's root type's field resolvers
+ * @param {Object} component - the component's whose root type field resolvers 
+ * will be proxied to
+ * @param {Object} resolvers - the source of potential resolver functions to 
+ * create a proxy for
+ * @returns {Object} - a resolver map that contains proxy functions for root 
+ * type field resolvers
+ */
 const createProxyResolvers = function (component, resolvers) {
   const proxyResolvers = {};
 
   const iterateRootTypeResolvers = function* () {
-    for (const name of Object.keys(resolvers)) {
-      if (['Query', 'Mutation', 'Subscription'].indexOf(name) > -1) {
-        yield [name, resolvers[name]];
+    for (const type of Object.keys(resolvers)) {
+      if (['Query', 'Mutation', 'Subscription'].indexOf(type) > -1) {
+        yield [type, resolvers[type]];
       }
     }
   };
 
-  for (const [root, fieldResolvers] of iterateRootTypeResolvers()) {
-    if (proxyResolvers[root] === undefined) {
-      proxyResolvers[root] = {};
+  for (const [rootType, fieldResolvers] of iterateRootTypeResolvers()) {
+    if (proxyResolvers[rootType] === undefined) {
+      proxyResolvers[rootType] = {};
     }
     for (const [field, resolver] of Object.entries(fieldResolvers)) {
       if (resolver.__isProxy === true) {
-        proxyResolvers[root][field] = resolver;
+        proxyResolvers[rootType][field] = resolver;
         continue;
       }
-      proxyResolvers[root][field] = createProxyResolver(component, root, field);
+      proxyResolvers[rootType][field] = createProxyResolver(component, rootType, field);
     }
   }
 

--- a/package.json
+++ b/package.json
@@ -24,11 +24,7 @@
     "@apollo/federation": "^0.10.3",
     "cuid": "^2.1.8",
     "debug": "^4.1.1",
-    "graphql-extensions": "^0.12.0",
-    "graphql-tag": "^2.10.3",
-    "graphql-tag-pluck": "^0.8.7",
-    "graphql-toolkit": "^0.7.5",
-    "graphql-tools": "^4.0.8",
+    "graphql-tools": "^6.0.10",
     "lodash.set": "^4.3.2"
   },
   "peerDependencies": {
@@ -40,6 +36,7 @@
     "casual": "^1.6.0",
     "eslint": "^6.5.1",
     "graphql": "^14",
+    "graphql-tag": "^2.10.3",
     "nyc": "^14.1.1",
     "tape": "^4.9.1"
   }


### PR DESCRIPTION
As discussed, this PR forward ports some recent changes:
* resolver tests refactor
* resolver utility function variable naming consistency refactor (around types, fields and their resolvers)
* migrate to latest graphql-tools and remove graphql-tool and associated peer dependencies
* move graphql-tag to a dev dependency
* exclude test files themselves from code coverage
* fix linting errors in tests that were failing the build
* minor README tweak around `preserveResolvers` and the `info` argument to `delegateToComponent`

Bug fix:
* pull up abstract non-root type special functions (__resolveType, __isTypeOf)