### PR TITLE
v2: minor clean up

### DIFF
--- a/lib/__tests__.js
+++ b/lib/__tests__.js
@@ -517,7 +517,6 @@ Test('proxy to child with root query that returns interface type (using __resolv
       },
       Thing: {
         __resolveType(parent) {
-          console.log('called');
           if (parent.name) {
             return 'Person';
           }

--- a/lib/index.js
+++ b/lib/index.js
@@ -41,7 +41,7 @@ class GraphQLComponent {
 
     this._resolvers = wrapResolvers(this, resolvers);
 
-    this._imports = imports && imports.length > 0 ? imports.map((i) => GraphQLComponent.isComponent(i) ? { component: i, excludes: [], proxyImportedResolvers: true } : i) : [];
+    this._imports = imports && imports.length > 0 ? imports.map((i) => GraphQLComponent.isComponent(i) ? { component: i, exclude: [] } : i) : [];
 
     this._dataSources = dataSources;
 

--- a/lib/resolvers/index.js
+++ b/lib/resolvers/index.js
@@ -294,9 +294,10 @@ const createProxyResolvers = function (component, resolvers) {
 };
 
 /**
- * helper to extract abstract non-root type resolvers (such as __resolveType) from a component's 
- * resolver
- * @param {*} component 
+ * helper to extract abstract non-root type resolvers (such as __resolveType) from a component's resolvers
+ * @param {Function} component to extract abstract non-root type resolvers from
+ * @returns {Object} - a resolver map containing only abstract non-root type 
+ * resolvers from the input component 
  */
 const getAbstractNonRootTypeResolvers = function (component) {
   const abstractNonRootTypeResolvers = {};


### PR DESCRIPTION
one last PR for some minor cleanup items I noticed:
* if we are importing a component, assign it to an object that has an exclude not excludes key
* remove proxyImportedResolvers flag since it's not used anywhere
* removed console.log
* complete doc string on helper function